### PR TITLE
Update to method storage and access

### DIFF
--- a/examples/recipe.py
+++ b/examples/recipe.py
@@ -4,8 +4,7 @@ import os
 import lciafmt
 from lciafmt.util import outputpath, store_method
 
-#To obtain LCIA endpoint set to True
-apply_endpoint = True
+method = lciafmt.Method.RECIPE_2016
 
 #To obtain summary LCIA endpoint categories (damage assessment) set to True
 apply_summary = False
@@ -14,7 +13,11 @@ def main():
     os.makedirs(outputpath, exist_ok=True)
 
     log.basicConfig(level=log.INFO)
-    data = lciafmt.get_method(lciafmt.Method.RECIPE_2016, endpoint = apply_endpoint, summary = apply_summary)
+    data = lciafmt.get_method(method, endpoint = False, 
+                              summary = False)
+    data_endpoint = lciafmt.get_method(method, endpoint = True, 
+                              summary = apply_summary)
+    data = data.append(data_endpoint, ignore_index = True)
     
     # make flowables case insensitive to handle lack of consistent structure in source file
     data['Flowable'] = data['Flowable'].str.lower()
@@ -22,16 +25,18 @@ def main():
     # map the flows to the Fed.LCA commons flows
     # set preserve_unmapped=True if you want to keep unmapped
     # flows in the resulting data frame
-    mapped_data = lciafmt.map_flows(data, system="ReCiPe2016", case_insensitive=True)
-    store_method(mapped_data, lciafmt.Method.RECIPE_2016.name)
+    mapping = method.get_metadata()['mapping']
+    mapped_data = lciafmt.map_flows(data, system=mapping, case_insensitive=True)
+    
+    # write the result to parquet and JSON-LD
+    store_method(mapped_data, method)
 
-    # write the result to JSON-LD and CSV
-    for method in mapped_data['Method'].unique():
-        mapped_data[mapped_data['Method']==method].to_csv(outputpath+method.replace('/','_')+".csv", index=False)
-        json_pack = outputpath+method.replace('/','_')+"_json.zip"
+    for m in mapped_data['Method'].unique():
+        mapped_data[mapped_data['Method']==m].to_csv(outputpath+m.replace('/','_')+".csv", index=False)
+        json_pack = outputpath+m.replace('/','_')+"_json.zip"
         if os.path.exists(json_pack):
             os.remove(json_pack)
-        data_for_json = mapped_data[mapped_data['Method']==method]
+        data_for_json = mapped_data[mapped_data['Method']==m]
         lciafmt.to_jsonld(data_for_json, json_pack)
 
 

--- a/examples/recipe.py
+++ b/examples/recipe.py
@@ -2,6 +2,7 @@ import logging as log
 import os
 
 import lciafmt
+from lciafmt.util import outputpath
 
 #To obtain LCIA endpoint set to True
 apply_endpoint = True
@@ -10,9 +11,6 @@ apply_endpoint = True
 apply_summary = False
 
 def main():
-    modulepath = os.path.dirname(
-        os.path.realpath(__file__)).replace('\\', '/')
-    outputpath = modulepath + '/../output/'
     os.makedirs(outputpath, exist_ok=True)
 
     log.basicConfig(level=log.INFO)

--- a/examples/recipe.py
+++ b/examples/recipe.py
@@ -2,7 +2,7 @@ import logging as log
 import os
 
 import lciafmt
-from lciafmt.util import outputpath
+from lciafmt.util import outputpath, store_method
 
 #To obtain LCIA endpoint set to True
 apply_endpoint = True
@@ -23,6 +23,7 @@ def main():
     # set preserve_unmapped=True if you want to keep unmapped
     # flows in the resulting data frame
     mapped_data = lciafmt.map_flows(data, system="ReCiPe2016", case_insensitive=True)
+    store_method(mapped_data, lciafmt.Method.RECIPE_2016.name)
 
     # write the result to JSON-LD and CSV
     for method in mapped_data['Method'].unique():

--- a/examples/traci.py
+++ b/examples/traci.py
@@ -2,13 +2,13 @@ import logging as log
 import os
 
 import lciafmt
-from lciafmt.util import outputpath
+from lciafmt.util import outputpath, store_method
 
 mod = None
 
 def main():
     os.makedirs(outputpath, exist_ok=True)
-    file = "traci_2.1"
+    file = lciafmt.Method.TRACI.name
     log.basicConfig(level=log.INFO)
     data = lciafmt.get_method(lciafmt.Method.TRACI)
     
@@ -29,6 +29,7 @@ def main():
     if mod is not None:
         file=mod+"_"+file
     mapped_data.to_csv(outputpath+file+".csv", index=False)
+    store_method(mapped_data, file)
     json_pack = outputpath+file+"_json.zip"
     if os.path.exists(json_pack):
         os.remove(json_pack)

--- a/examples/traci.py
+++ b/examples/traci.py
@@ -2,15 +2,13 @@ import logging as log
 import os
 
 import lciafmt
+from lciafmt.util import outputpath
 
 mod = None
 
 def main():
-    modulepath = os.path.dirname(
-        os.path.realpath(__file__)).replace('\\', '/')
-    outputpath = modulepath + '/../output/'
     os.makedirs(outputpath, exist_ok=True)
-
+    file = "traci_2.1"
     log.basicConfig(level=log.INFO)
     data = lciafmt.get_method(lciafmt.Method.TRACI)
     
@@ -29,9 +27,9 @@ def main():
 
     # write the result to JSON-LD and CSV
     if mod is not None:
-        outputpath=outputpath+mod+"_"
-    mapped_data.to_csv(outputpath+"traci_2.1.csv", index=False)
-    json_pack = outputpath+"traci_2.1_json.zip"
+        file=mod+"_"+file
+    mapped_data.to_csv(outputpath+file+".csv", index=False)
+    json_pack = outputpath+file+"_json.zip"
     if os.path.exists(json_pack):
         os.remove(json_pack)
     lciafmt.to_jsonld(mapped_data, json_pack)

--- a/examples/traci.py
+++ b/examples/traci.py
@@ -6,11 +6,14 @@ from lciafmt.util import outputpath, store_method
 
 mod = None
 
+method = lciafmt.Method.TRACI
+
 def main():
     os.makedirs(outputpath, exist_ok=True)
-    file = lciafmt.Method.TRACI.name
     log.basicConfig(level=log.INFO)
-    data = lciafmt.get_method(lciafmt.Method.TRACI)
+    file = method.get_filename()
+
+    data = lciafmt.get_method(method)
     
     if mod is not None:
         log.info("getting modified CFs")
@@ -23,18 +26,17 @@ def main():
     # map the flows to the Fed.LCA commons flows
     # set preserve_unmapped=True if you want to keep unmapped
     # flows in the resulting data frame
-    mapped_data = lciafmt.map_flows(data, system="TRACI2.1")
+    mapping = method.get_metadata()['mapping']
+    mapped_data = lciafmt.map_flows(data, system=mapping)
 
-    # write the result to JSON-LD and CSV
+    # write the result to parquet and JSON-LD
+    store_method(mapped_data, method)
     if mod is not None:
         file=mod+"_"+file
-    mapped_data.to_csv(outputpath+file+".csv", index=False)
-    store_method(mapped_data, file)
     json_pack = outputpath+file+"_json.zip"
     if os.path.exists(json_pack):
         os.remove(json_pack)
     lciafmt.to_jsonld(mapped_data, json_pack)
-
 
 
 if __name__ == "__main__":

--- a/lciafmt/__init__.py
+++ b/lciafmt/__init__.py
@@ -3,6 +3,7 @@ import logging as log
 import pkg_resources
 
 import pandas as pd
+import os
 
 import lciafmt.cache as cache
 import lciafmt.fmap as fmap
@@ -65,11 +66,26 @@ def supported_mapping_systems() -> list:
        function."""
     return fmap.supported_mapping_systems()
 
+def get_mapped_method(method_id):
+    if os.path.exists(util.outputpath+method_id.name+".parquet"):
+        return read_method(method_id)
+    method = get_method(method_id)
+    if method_id == Method.RECIPE_2016.value or method_id == Method.RECIPE_2016:
+        case_insensitive = True
+        mapping_system = 'ReCiPe2016'
+        method['Flowable'] = method['Flowable'].str.lower()
+    else:
+        case_insensitive = False
+        mapping_system = method_id
+    mapped_method = map_flows(method, system=mapping_system, case_insensitive=case_insensitive)
+    return mapped_method
+
 def read_method(method_id):
     """Returns the method stored in output."""
     method = pd.DataFrame()
-    file = util.outputpath+method_id+".parquet"
+    file = util.outputpath+method_id.name+".parquet"
     try:
+        log.info('reading stored method file')
         method = pd.read_parquet(file)
     except FileNotFoundError:
         log.error('No file identified for ' + method_id)

--- a/lciafmt/__init__.py
+++ b/lciafmt/__init__.py
@@ -79,7 +79,7 @@ def supported_mapping_systems() -> list:
        function."""
     return fmap.supported_mapping_systems()
 
-def get_mapped_method(method_id, subset=None):
+def get_mapped_method(method_id, indicator=None, method=None):
     filename = method_id.get_filename()
     if os.path.exists(util.outputpath+filename+".parquet"):
         mapped_method = read_method(method_id)
@@ -90,10 +90,14 @@ def get_mapped_method(method_id, subset=None):
         if case_insensitive:
             method['Flowable'] = method['Flowable'].str.lower()
         mapped_method = map_flows(method, system=mapping_system, case_insensitive=case_insensitive)
-    if subset is not None:
-        mapped_method = mapped_method[mapped_method['Indicator'].isin(subset)]
+    if indicator is not None:
+        mapped_method = mapped_method[mapped_method['Indicator'].isin(indicator)]
         if len(mapped_method) == 0:
-            log.info('subset not found')
+            log.info('indicator not found')
+    if method is not None:
+        mapped_method = mapped_method[mapped_method['Method'].isin(method)]
+        if len(mapped_method) == 0:
+            log.info('specified method not found')
     return mapped_method
 
 def read_method(method_id):

--- a/lciafmt/__init__.py
+++ b/lciafmt/__init__.py
@@ -64,3 +64,13 @@ def supported_mapping_systems() -> list:
     """Returns the mapping systems that are supported in the `map_flows`
        function."""
     return fmap.supported_mapping_systems()
+
+def read_method(method_id):
+    """Returns the method stored in output."""
+    method = pd.DataFrame()
+    file = util.outputpath+method_id+".parquet"
+    try:
+        method = pd.read_parquet(file)
+    except FileNotFoundError:
+        log.error('No file identified for ' + method_id)
+    return method

--- a/lciafmt/__init__.py
+++ b/lciafmt/__init__.py
@@ -80,6 +80,8 @@ def supported_mapping_systems() -> list:
     return fmap.supported_mapping_systems()
 
 def get_mapped_method(method_id, indicator=None, method=None):
+    """Obtains a mapped method stored as parquet, if that file does not exist
+    locally, it is generated"""
     filename = method_id.get_filename()
     if os.path.exists(util.outputpath+filename+".parquet"):
         mapped_method = read_method(method_id)

--- a/lciafmt/__init__.py
+++ b/lciafmt/__init__.py
@@ -93,11 +93,11 @@ def get_mapped_method(method_id, indicator=None, method=None):
     if indicator is not None:
         mapped_method = mapped_method[mapped_method['Indicator'].isin(indicator)]
         if len(mapped_method) == 0:
-            log.info('indicator not found')
+            log.error('indicator not found')
     if method is not None:
         mapped_method = mapped_method[mapped_method['Method'].isin(method)]
         if len(mapped_method) == 0:
-            log.info('specified method not found')
+            log.error('specified method not found')
     return mapped_method
 
 def read_method(method_id):
@@ -111,3 +111,20 @@ def read_method(method_id):
     except FileNotFoundError:
         log.error('No file identified for ' + method_id)
     return method
+
+def supported_indicators(method_id):
+    """Returns a list of indicators for the identified method."""
+    method = read_method(method_id)
+    indicators = set(list(method['Indicator']))
+    return list(indicators)
+
+def supported_stored_methods():
+    """Returns a list of methods stored as parquet."""
+    methods = pd.DataFrame()
+    files = os.listdir(util.outputpath)
+    for name in files:
+        if name.endswith(".parquet"):
+            method = pd.read_parquet(util.outputpath+name)
+            methods = pd.concat([methods, method])
+    methods_list = set(list(methods['Method']))
+    return list(methods_list)   

--- a/lciafmt/data/methods.json
+++ b/lciafmt/data/methods.json
@@ -1,16 +1,20 @@
 [
   {
-    "id": "TRACI 2.1",
+    "id": "TRACI",
     "name": "TRACI 2.1",
     "version": "2.1",
+    "mapping": "TRACI2.1",
     "description": "...",
+    "case_insensitivity": "False",
     "url": "https://www.epa.gov/sites/production/files/2015-12/traci_2_1_2014_dec_10_0.xlsx"
   },
   {
-    "id": "ReCiPe 2016",
+    "id": "RECIPE_2016",
     "name": "ReCiPe 2016",
     "version": "1.1",
+    "mapping": "ReCiPe2016",
     "description": "...",
+    "case_insensitivity": "True",
     "url": "http://www.rivm.nl/sites/default/files/2018-11/ReCiPe2016_CFs_v1.1_20180117.xlsx"
   }
 ]

--- a/lciafmt/util.py
+++ b/lciafmt/util.py
@@ -125,9 +125,10 @@ def get_method_metadata(name: str) -> str:
         log.info("No further detail in description")
     return method_description
 
-def store_method(method, filename):
+def store_method(df, method_id):
     """Prints the method as a dataframe to parquet file"""
+    filename = method_id.get_filename()
     try:
-        method.to_parquet(outputpath+filename+".parquet")
+        df.to_parquet(outputpath+filename+".parquet")
     except:
         log.error('Failed to save method')

--- a/lciafmt/util.py
+++ b/lciafmt/util.py
@@ -124,3 +124,10 @@ def get_method_metadata(name: str) -> str:
     except:
         log.info("No further detail in description")
     return method_description
+
+def store_method(method, filename):
+    """Prints the method as a dataframe to parquet file"""
+    try:
+        method.to_parquet(outputpath+filename+".parquet")
+    except:
+        log.error('Failed to save method')

--- a/lciafmt/util.py
+++ b/lciafmt/util.py
@@ -6,7 +6,9 @@ import os
 from os.path import join
 import logging as log
 
-datapath = os.path.dirname(os.path.realpath(__file__)).replace('\\', '/')+'/data/'
+modulepath = os.path.dirname(os.path.realpath(__file__)).replace('\\', '/')
+outputpath = modulepath + '/../output/'
+datapath = modulepath + '/data/'
 
 def make_uuid(*args: str) -> str:
     path = _as_path(*args)


### PR DESCRIPTION
-when generating methods via script, saves as parquet file
-new function get_mapped_method to enable access to lciamethod after mapping, passed parameters to limit to a subset of indicators or specific methods (e.g. ReCiPe midpoint/H), will use stored parquet first if available
-new functions to identify available indicators or methods within a parquet
-updates to the Method class and methods.json to better align naming across methods for consistency
-output folder remains in gitignore, parquet files are not stored on github