### PR TITLE
fixing fossil resource endpoint CFs for ReCiPe2016

### DIFF
--- a/lciafmt/recipe.py
+++ b/lciafmt/recipe.py
@@ -78,6 +78,10 @@ def get(add_factors_for_missing_contexts=True, endpoint=True,
         df2 = pd.concat([df2, flowdf], ignore_index=True, sort=False)
         # reformat dataframe and apply conversion
         df2['Characterization Factor'] = df2['Characterization Factor'] * df2['EndpointConversion']
+        # in the case of fossil resource scarcity, EndpointConversion factors are the actual Endpoint Characterization factors
+        fossil_exception = endpoint_df_by_flow['Flowable'].values
+        df2.loc[df2['Flowable'].isin(fossil_exception),'Characterization Factor'] = df2.loc[df2['Flowable'].isin(fossil_exception),'EndpointConversion']
+
         df2['Method'] = df2['EndpointMethod']
         df2['Indicator'] = df2['EndpointIndicator']
         df2['Indicator unit'] = df2['EndpointUnit']


### PR DESCRIPTION
In the current version of LCIAFormatter, endpoint characterization factors for fossil resource scarcity are being treated as midpoint-to-endpoint conversion factors, leading to wrong characterization factors at the endpoint "Damage to resource availability". This PR fixes this.

Context (from the original ReCiPe file):

![image](https://github.com/USEPA/LCIAformatter/assets/18268750/8c244c60-3fd7-4896-973d-25d6791b9997)
@Ercollao
