### PR TITLE
Updates to use olca-schema to replace olca-ipc

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        py-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        py-version: ['3.9', '3.10', '3.11']
         
     steps:
     - uses: actions/checkout@v3

--- a/lciafmt/cache.py
+++ b/lciafmt/cache.py
@@ -52,6 +52,7 @@ def download(url: str, file: str) -> str:
     path = get_path(file)
     log.info(f"downloading from {url} to {path}")
     resp = requests.get(url, allow_redirects=True)
+    resp.raise_for_status()
     with open(path, "wb") as f:
         f.write(resp.content)
     return path

--- a/lciafmt/data/description.yaml
+++ b/lciafmt/data/description.yaml
@@ -21,3 +21,6 @@ description:
     
     
     '
+
+indicator:
+    '[Indicator] is built from LCIA Formatter v[LCIAfmt_version] for use with [Method]'

--- a/lciafmt/data/methods.json
+++ b/lciafmt/data/methods.json
@@ -6,7 +6,7 @@
     "path": "traci",
     "mapping": "TRACI2.1",
     "case_insensitivity": "False",
-    "url": "https://www.epa.gov/sites/production/files/2015-12/traci_2_1_2014_dec_10_0.xlsx",
+    "url": "https://www.epa.gov/sites/default/files/2015-12/traci_2_1_2014_dec_10_0.xlsx",
     "citation": "Bare 2012",
     "source_type": "Excel file"
   },

--- a/lciafmt/jsonld.py
+++ b/lciafmt/jsonld.py
@@ -69,7 +69,7 @@ class Writer(object):
         ind = o.ImpactCategory()
         ind.id = uid
         ind.name = row[2]
-        ind.reference_unit_name = row[4]
+        ind.ref_unit = row[4]
         ind.impact_factors = []
         self.__indicators[uid] = ind
 
@@ -77,7 +77,7 @@ class Writer(object):
         ref = o.ImpactCategory()
         ref.id = uid
         ref.name = ind.name
-        ref.ref_unit = ind.reference_unit_name
+        ref.ref_unit = ind.ref_unit
         method.impact_categories.append(ref)
         return ind
 

--- a/lciafmt/jsonld.py
+++ b/lciafmt/jsonld.py
@@ -74,7 +74,8 @@ class Writer(object):
         direction = ('INPUT' if row['Context'].startswith('resource')
                      else 'OUTPUT')
         ind.direction = o.Direction(direction)
-        # ind.description = ''
+        ind.description = generate_method_description(row['Method'],
+                                                      row['Indicator'])
         ind.impact_factors = []
         ind.version = pkg_version_number
         self.__indicators[uid] = ind

--- a/lciafmt/traci.py
+++ b/lciafmt/traci.py
@@ -10,6 +10,7 @@ Impacts (TRACI)
 import pandas as pd
 import openpyxl
 
+import lciafmt
 import lciafmt.cache as cache
 import lciafmt.df as dfutil
 import lciafmt.xls as xls
@@ -34,12 +35,12 @@ def get(add_factors_for_missing_contexts=True, file=None,
     :return: DataFrame of method in standard format
     """
     log.info("getting method Traci 2.1")
+    method_meta = lciafmt.Method.TRACI.get_metadata()
     f = file
     if f is None:
         fname = "traci_2.1.xlsx"
         if url is None:
-            url = ("https://www.epa.gov/sites/production/files/2015-12/" +
-                   "traci_2_1_2014_dec_10_0.xlsx")
+            url = method_meta['url']
         f = cache.get_or_download(fname, url)
     df = _read(f)
     if add_factors_for_missing_contexts:

--- a/lciafmt/util.py
+++ b/lciafmt/util.py
@@ -170,10 +170,10 @@ def check_as_class(method_id):
     return method_id
 
 
-def generate_method_description(name: str) -> str:
+def generate_method_description(name: str, indicator: str='') -> str:
     with open(datapath / "description.yaml") as f:
         generic = yaml.safe_load(f)
-    method_description = generic['description']
+    desc = generic['description']
     method = check_as_class(name)
     if method is None:
         method_meta = {}
@@ -183,26 +183,32 @@ def generate_method_description(name: str) -> str:
     else:
         method_meta = method.get_metadata()
     if 'detail_note' in method_meta:
-        method_description += method_meta['detail_note']
+        desc += method_meta['detail_note']
     if 'methods' in method_meta:
         try:
             detailed_meta = '\n\n' + method_meta['methods'][name]
-            method_description += detailed_meta
+            desc += detailed_meta
         except KeyError:
             log.debug(f'{name} not found in methods.json')
+    if indicator:
+        desc = generic['indicator']
+
     # Replace tagged fields
     if 'version' in method_meta:
         version = ' (v' + method_meta['version'] + ')'
     else:
         version = ''
-    method_description = method_description.replace('[LCIAfmt_version]', pkg_version_number)
-    method_description = method_description.replace('[FEDEFL_version]', flow_list_specs['list_version'])
-    method_description = method_description.replace('[Method]', method_meta['name'])
-    method_description = method_description.replace('[version]', version)
-    method_description = method_description.replace('[citation]', method_meta['citation'])
-    method_description = method_description.replace('[url]', method_meta['url'])
+    desc = (desc
+            .replace('[LCIAfmt_version]', pkg_version_number)
+            .replace('[FEDEFL_version]', flow_list_specs['list_version'])
+            .replace('[Method]', method_meta['name'])
+            .replace('[version]', version)
+            .replace('[citation]', method_meta['citation'])
+            .replace('[url]', method_meta['url'])
+            .replace('[Indicator]', indicator)
+            )
 
-    return method_description
+    return desc
 
 
 def compile_metadata(method_id):
@@ -258,13 +264,14 @@ def download_method(method_id):
     download_from_remote(meta, paths)
 
 
-def save_json(method_id, mapped_data, method=None, name=''):
+def save_json(method_id, mapped_data, method=None, name='', write_flows=False):
     """Save a method as json file in the outputpath.
 
     :param method_id: class Method
     :param mapped_data: df of mapped method to save
     :param method: str, name of method to subset the passed mapped_data
     :param name: str, optional method name when method_id does not exist
+    :param write_flows: bool
     """
     meta = set_lcia_method_meta(method_id)
     if name == '':
@@ -278,7 +285,7 @@ def save_json(method_id, mapped_data, method=None, name=''):
     mkdir_if_missing(OUTPUTPATH)
     json_pack = path / f'{filename}_json_v{meta.tool_version}.zip'
     json_pack.unlink(missing_ok=True)
-    lciafmt.to_jsonld(mapped_data, json_pack)
+    lciafmt.to_jsonld(mapped_data, json_pack, write_flows=write_flows)
 
 
 def compare_to_remote(local_df, method_id):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@develop#egg=fedelemflowlist
 git+https://github.com/USEPA/esupy.git@develop#egg=esupy
-olca-ipc>=0.0.12
+olca-schema>=0.0.11
 pandas>=0.23
 requests>=2.21.0
 openpyxl>=3.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@develop#egg=fedelemflowlist
+git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@olca#egg=fedelemflowlist
 git+https://github.com/USEPA/esupy.git@develop#egg=esupy
 olca-schema>=0.0.11
 pandas>=0.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@olca#egg=fedelemflowlist
+git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@develop#egg=fedelemflowlist
 git+https://github.com/USEPA/esupy.git@develop#egg=esupy
 olca-schema>=0.0.11
 pandas>=0.23

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     package_dir={'lciafmt': 'lciafmt'},
     package_data={'lciafmt': ["data/*.*"]},
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     install_requires=["fedelemflowlist @ git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@olca#egg=fedelemflowlist",
                       "esupy @ git+https://github.com/USEPA/esupy.git@develop#egg=esupy",
                       "olca-schema>=0.0.11",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     package_data={'lciafmt': ["data/*.*"]},
     include_package_data=True,
     python_requires=">=3.7",
-    install_requires=["fedelemflowlist @ git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@develop#egg=fedelemflowlist",
+    install_requires=["fedelemflowlist @ git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@olca#egg=fedelemflowlist",
                       "esupy @ git+https://github.com/USEPA/esupy.git@develop#egg=esupy",
                       "olca-schema>=0.0.11",
                       "pandas>=0.22",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     package_data={'lciafmt': ["data/*.*"]},
     include_package_data=True,
     python_requires=">=3.9",
-    install_requires=["fedelemflowlist @ git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@olca#egg=fedelemflowlist",
+    install_requires=["fedelemflowlist @ git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@develop#egg=fedelemflowlist",
                       "esupy @ git+https://github.com/USEPA/esupy.git@develop#egg=esupy",
                       "olca-schema>=0.0.11",
                       "pandas>=0.22",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     python_requires=">=3.7",
     install_requires=["fedelemflowlist @ git+https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List.git@develop#egg=fedelemflowlist",
                       "esupy @ git+https://github.com/USEPA/esupy.git@develop#egg=esupy",
-                      "olca-ipc>=0.0.12",
+                      "olca-schema>=0.0.11",
                       "pandas>=0.22",
                       "openpyxl>=3.0.7",
                       "pyyaml>=5.3"


### PR DESCRIPTION
Supports the creation of LCIA methods for openLCA 2.0
Drops support for python 3.7 and 3.8 (due to requirements in olca-schema)

Requires https://github.com/USEPA/Federal-LCA-Commons-Elementary-Flow-List/pull/177