### PR TITLE
use `.to_ref()` to avoid unnecessary data

### DIFF
--- a/lciafmt/jsonld.py
+++ b/lciafmt/jsonld.py
@@ -74,7 +74,7 @@ class Writer(object):
             indicator = self.__indicator(row)
             factor = o.ImpactFactor()
             unit = row['Unit']
-            factor.flow = self.__flow(row)
+            factor.flow = self.__flow(row).to_ref()
             factor.flow_property = units.property_ref(unit)
             factor.unit = units.unit_ref(unit)
             factor.value = row['Characterization Factor']


### PR DESCRIPTION
resolves #114